### PR TITLE
opts hash was not being passed in to parse_epraw.

### DIFF
--- a/lib/paxmex.rb
+++ b/lib/paxmex.rb
@@ -5,7 +5,7 @@ module Paxmex
     Parser.new(file, schema: 'eptrn').parse(opts)
   end
 
-  def self.parse_epraw(file)
+  def self.parse_epraw(file, opts = {})
     Parser.new(file, schema: 'epraw').parse(opts)
   end
 end


### PR DESCRIPTION
The EPRaw parsing functionality is broken. This pull request should take care of the problem.

This is the exception. 

```
irb(main):001:0> require 'paxmex'
=> true
irb(main):002:0> Paxmex.parse_epraw('path_to_file')
NameError: undefined local variable or method `opts' for Paxmex:Module
    from /Library/Ruby/Gems/2.0.0/gems/paxmex-1.0.0/lib/paxmex.rb:9:in `parse_epraw'
    from (irb):2
    from /usr/bin/irb:12:in `<main>'

paxmex.rb:9:in `parse_epraw': undefined local variable or method `opts' for Paxmex:Module (NameError)
```
