### PR TITLE
Fix Parser.new to load content from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1
+* Fix Parser.new(...) to properly load content from file.
+* Prevent BigDecimal.new deprecation warning.
+
 # 2.0.0
 * Allow loading content from a string as well as from a file.
 * Introduce new public interface for parsing and loading, eg. Paxmex.epraw.parse(...).

--- a/lib/paxmex/parser.rb
+++ b/lib/paxmex/parser.rb
@@ -11,8 +11,13 @@ class Paxmex::Parser
   attr_reader :schema, :path
 
   def initialize(data, schema)
-    @data = data.chomp
     @parent_chain = []
+
+    if File.file?(data)
+      @data = File.read(data).chomp
+    else
+      @data = data.chomp
+    end
 
     if File.file?(schema)
       @schema = Paxmex::Schema.new(YAML.load_file(schema))

--- a/lib/paxmex/schema/field.rb
+++ b/lib/paxmex/schema/field.rb
@@ -60,7 +60,7 @@ module Paxmex
           '{'=>0, '}'=>0)
 
         parsed_value = value.to_i * (is_credit ? -1 : 1) / 100.0
-        BigDecimal.new(parsed_value.to_s, 7)
+        BigDecimal(parsed_value.to_s, 7)
       end
 
       def parse_julian_date(date_string)

--- a/lib/paxmex/version.rb
+++ b/lib/paxmex/version.rb
@@ -1,3 +1,3 @@
 module Paxmex
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -26,6 +26,11 @@ describe Paxmex::Parser do
 
       expect(schema_1.to_h).to eq(schema_2.to_h)
     end
+
+    it 'accepts an epa file and a schema file' do
+      epa_file_with_schema = Paxmex::Parser.new(epa_file, schema_file_epa)
+      expect(epa_file_with_schema.raw).to eq(File.read(epa_file).chomp)
+    end
   end
 
   describe '#raw' do


### PR DESCRIPTION
When using `Parser.new(path_to_file, path_to_schema)`, `path_to_file` was handled verbatim as string, and not as a file path. Spec tests were not catching this. Both issues are fixed.

Additionally, parsing was giving a warning about deprecation of BigDecimal.new(), which was taken care of, too.